### PR TITLE
Union type support

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@
 
 """
 
-def  test():    
+def  test():
     from idl_parser import parser
     _parser = parser.IDLParser()
     idl_str = '''
@@ -12,32 +12,32 @@ module my_module {
     long usec;
   };
 
-  enum union_descriminator_kind
+  enum UNION_DESCRIMINATOR_KIND
   {
-      PARAMETER_VALUE_UNKNOWN,
-      PARAMETER_VALUE_ULONGLONG,
-      PARAMETER_VALUE_LONGLONG,
-      PARAMETER_VALUE_DOUBLE,
-      PARAMETER_VALUE_STRING,
-      PARAMETER_VALUE_KIND_COUNT
+      DESCRIMINATOR_UNKNOWN,
+      DESCRIMINATOR_ULONGLONG,
+      DESCRIMINATOR_LONGLONG,
+      DESCRIMINATOR_DOUBLE,
+      DESCRIMINATOR_STRING,
+      DESCRIMINATOR_KIND_COUNT
   };
 
-  union union_value switch( union_descriminator_kind )
+  union UnionType switch( UNION_DESCRIMINATOR_KIND )
   {
-      case PARAMETER_VALUE_UNKNOWN:
-      case PARAMETER_VALUE_KIND_COUNT:
-      case PARAMETER_VALUE_ULONGLONG:
+      case DESCRIMINATOR_UNKNOWN:
+      case DESCRIMINATOR_COUNT:
+      case DESCRIMINATOR_ULONGLONG:
           unsigned long long      ull_value;
-      case PARAMETER_VALUE_LONGLONG:
+      case DESCRIMINATOR_LONGLONG:
           long long               ll_value;
-      case PARAMETER_VALUE_DOUBLE:
+      case DESCRIMINATOR_DOUBLE:
           double                  d_value;
-      case PARAMETER_VALUE_STRING:
+      case DESCRIMINATOR_STRING:
           sequence<char>          str_value;
   };
 
   typedef sequence<double> DoubleSeq;
-  
+
   struct TimedDoubleSeq {
     Time tm;
     DoubleSeq data;
@@ -52,8 +52,8 @@ module my_module {
     RETURN_VALUE getData(out TimedDoubleSeq data);
   };
 };
-'''    
-    
+'''
+
     global_module = _parser.load(idl_str)
     my_module = global_module.module_by_name('my_module')
     dataGetter = my_module.interface_by_name('DataGetter')
@@ -67,16 +67,26 @@ module my_module {
         print '    name:', a.name
         print '    type:', a.type
         print '    direction:', a.direction
-        
+
     doubleSeq = my_module.typedef_by_name('DoubleSeq')
     print 'typedef %s %s' % (doubleSeq.type.name, doubleSeq.name)
+
+    unionType = my_module.union_by_name('UnionType')
+    print 'descriminator kind: %s' % unionType.descriminator_kind
+    for m in unionType.members:
+        print '- member:'
+        print '  name:', m.name
+        print '  type:', m.type.name
+        print 'descriminator value associations:'
+        for a in m.descriminator_value_associations:
+            print '    %s' % a
 
     timedDoubleSeq = my_module.struct_by_name('TimedDoubleSeq')
     print 'TimedDoubleSeq'
     for m in timedDoubleSeq.members:
       print '- member:'
       print '  name:', m.name
-      print '  type:', m.type.name    
+      print '  type:', m.type.name
 
 
 if __name__ == '__main__':

--- a/example.py
+++ b/example.py
@@ -25,7 +25,7 @@ module my_module {
   union UnionType switch( UNION_DESCRIMINATOR_KIND )
   {
       case DESCRIMINATOR_UNKNOWN:
-      case DESCRIMINATOR_COUNT:
+      case DESCRIMINATOR_KIND_COUNT:
       case DESCRIMINATOR_ULONGLONG:
           unsigned long long      ull_value;
       case DESCRIMINATOR_LONGLONG:

--- a/example.py
+++ b/example.py
@@ -33,7 +33,7 @@ module my_module {
       case DESCRIMINATOR_DOUBLE:
           double                  d_value;
       case DESCRIMINATOR_STRING:
-          sequence<char>          str_value;
+          sequence<char>     str_value;
   };
 
   typedef sequence<double> DoubleSeq;

--- a/example.py
+++ b/example.py
@@ -12,6 +12,30 @@ module my_module {
     long usec;
   };
 
+  enum union_descriminator_kind
+  {
+      PARAMETER_VALUE_UNKNOWN,
+      PARAMETER_VALUE_ULONGLONG,
+      PARAMETER_VALUE_LONGLONG,
+      PARAMETER_VALUE_DOUBLE,
+      PARAMETER_VALUE_STRING,
+      PARAMETER_VALUE_KIND_COUNT
+  };
+
+  union union_value switch( union_descriminator_kind )
+  {
+      case PARAMETER_VALUE_UNKNOWN:
+      case PARAMETER_VALUE_KIND_COUNT:
+      case PARAMETER_VALUE_ULONGLONG:
+          unsigned long long      ull_value;
+      case PARAMETER_VALUE_LONGLONG:
+          long long               ll_value;
+      case PARAMETER_VALUE_DOUBLE:
+          double                  d_value;
+      case PARAMETER_VALUE_STRING:
+          sequence<char>          str_value;
+  };
+
   typedef sequence<double> DoubleSeq;
   
   struct TimedDoubleSeq {

--- a/idl_parser/enum.py
+++ b/idl_parser/enum.py
@@ -36,12 +36,12 @@ class IDLEnumValue(node.IDLNode):
     @property
     def value(self):
         return self._value
-    
+
 
 
 
 class IDLEnum(node.IDLNode):
-    
+
     def __init__(self, name, parent):
         super(IDLEnum, self).__init__('IDLEnum', name, parent)
         self._verbose = True
@@ -50,10 +50,10 @@ class IDLEnum(node.IDLNode):
     def to_simple_dic(self, quiet=False, full_path=False, recursive=False, member_only=False):
         name = self.full_path if full_path else self.name
         if quiet:
-            return 'enum %s' % name 
+            return 'enum %s' % name
         dic = { 'enum %s' % name : [v.to_simple_dic() for v in self.values] }
         return dic
-                    
+
 
     def to_dic(self):
         dic = { 'name' : self.name,
@@ -64,7 +64,7 @@ class IDLEnum(node.IDLNode):
     @property
     def full_path(self):
         return self.parent.full_path + sep + self.name
-    
+
     def parse_tokens(self, token_buf, filepath=None):
         self._filepath = filepath
         self._counter = 0
@@ -72,14 +72,14 @@ class IDLEnum(node.IDLNode):
         if not kakko == '{':
             if self._verbose: sys.stdout.write('# Error. No kakko "{".\n')
             raise InvalidIDLSyntaxError()
-        
-        block_tokens = []        
+
+        block_tokens = []
         while True:
             token = token_buf.pop()
             if token == None:
                 if self._verbose: sys.stdout.write('# Error. No kokka "}".\n')
                 raise InvalidIDLSyntaxError()
-            
+
             elif token == '}':
                 token = token_buf.pop()
                 if not token == ';':
@@ -89,13 +89,13 @@ class IDLEnum(node.IDLNode):
                 if len(block_tokens) > 0:
                     self._parse_block(block_tokens)
                 break
-            
+
             if token == ',':
                 self._parse_block(block_tokens)
                 block_tokens = []
                 continue
             block_tokens.append(token)
-            
+
     def _parse_block(self, blocks):
         v = IDLEnumValue(self._counter, self)
         self._counter = self._counter+ 1

--- a/idl_parser/interface.py
+++ b/idl_parser/interface.py
@@ -44,10 +44,10 @@ class IDLArgument(node.IDLNode):
         return self._type
 
     def post_process(self):
-        #self._type = self.refine_typename(self.type)
-        pass
+        self._type._name = self.refine_typename(self.type)
 
-        
+
+
 class IDLMethod(node.IDLNode):
     def __init__(self, parent):
         super(IDLMethod, self).__init__('IDLValue', '', parent)
@@ -71,7 +71,7 @@ class IDLMethod(node.IDLNode):
         if not blocks[2] == '(':
             print(' -- Invalid Interface Token (%s)' % interface_name)
             print( blocks)
-            
+
         index = 3
         argument_blocks = []
         while True:
@@ -130,12 +130,12 @@ class IDLMethod(node.IDLNode):
         pass
 
 class IDLInterface(node.IDLNode):
-    
+
     def __init__(self, name, parent):
         super(IDLInterface, self).__init__('IDLInterface', name, parent)
         self._verbose = True
         self._methods = []
-        
+
     @property
     def full_path(self):
         return self.parent.full_path + sep + self.name
@@ -148,33 +148,33 @@ class IDLInterface(node.IDLNode):
 
     def to_dic(self):
         dic = { 'name' : self.name,
-                'filepath' : self.filepath, 
+                'filepath' : self.filepath,
                 'classname' : self.classname,
                 'methods' : [m.to_dic() for m in self.methods] }
         return dic
-    
+
     def parse_tokens(self, token_buf, filepath=None):
         self._filepath=filepath
         kakko = token_buf.pop()
         if not kakko == '{':
             if self._verbose: sys.stdout.write('# Error. No kakko "{".\n')
             raise InvalidIDLSyntaxError()
-        
-        block_tokens = []        
+
+        block_tokens = []
         while True:
 
             token = token_buf.pop()
             if token == None:
                 if self._verbose: sys.stdout.write('# Error. No kokka "}".\n')
                 raise InvalidIDLSyntaxError()
-            
+
             elif token == '}':
                 token = token_buf.pop()
                 if not token == ';':
                     if self._verbose: sys.stdout.write('# Error. No semi-colon after "}".\n')
                     raise InvalidIDLSyntaxError()
                 break
-            
+
             if token == ';':
                 self._parse_block(block_tokens)
                 block_tokens = []
@@ -204,4 +204,4 @@ class IDLInterface(node.IDLNode):
         for m in self.methods:
             func(m)
 
-        
+

--- a/idl_parser/module.py
+++ b/idl_parser/module.py
@@ -1,7 +1,7 @@
 import os, sys, traceback
 
 from . import node, type
-from . import struct, typedef, interface, enum, const
+from . import struct, typedef, interface, enum, const, union
 global_namespace = '__global__'
 sep = '::'
 
@@ -17,6 +17,7 @@ class IDLModule(node.IDLNode):
         self._typedefs = []
         self._structs = []
         self._enums = []
+        self._unions = []
         self._consts = []
         self._modules = []
 
@@ -38,6 +39,7 @@ class IDLModule(node.IDLNode):
                [i.to_simple_dic(quiet) for i in self.interfaces] +
                [m.to_simple_dic(quiet) for m in self.modules] + 
                [e.to_simple_dic(quiet) for e in self.enums] + 
+               [u.to_simple_dic(quiet) for e in self.unions] + 
                [t.to_simple_dic(quiet) for t in self.typedefs] + 
                [t.to_simple_dic(quiet) for t in self.consts]}
         return dic
@@ -50,6 +52,7 @@ class IDLModule(node.IDLNode):
                 'typedefs' : [t.to_dic() for t in self.typedefs],
                 'structs' : [s.to_dic() for s in self.structs],
                 'enums' : [e.to_dic() for e in self.enums],
+                'unions' : [u.to_dic() for e in self.unions],
                 'modules' : [m.to_dic() for m in self.modules],
                 'consts' : [c.to_dic() for c in self.consts] }
         return dic
@@ -124,7 +127,16 @@ class IDLModule(node.IDLNode):
                 else:
                     self._enums.append(s)
 
-                pass
+            elif token == 'union':
+                name_ = token_buf.pop()
+                s = union.IDLUnion(name_, self)
+                s.parse_tokens(token_buf, filepath)
+                s_ = self.union_by_name(name_)
+                if s_:
+                    if self._verbose: sys.stdout.write('# Error. Same Union Defined (%s)\n' % name_)
+                #    raise InvalidIDLSyntaxError
+                else:
+                    self._unions.append(s)
 
             elif token == 'const':
                 values = []
@@ -224,6 +236,22 @@ class IDLModule(node.IDLNode):
         return retval
 
     @property
+    def unions(self):
+        return self._unions
+
+    def union_by_name(self, name):
+        for u in self.unions:
+            if u.name == name:
+                return u
+        return None
+
+    def for_each_union(self, func):
+        retval = []
+        for m in self.unions:
+            retval.append(func(m))
+        return retval
+
+    @property
     def consts(self):
         return self._consts
 
@@ -269,6 +297,7 @@ class IDLModule(node.IDLNode):
             m.for_each_struct(parse_node)
             m.for_each_typedef(parse_node)
             m.for_each_enum(parse_node)
+            m.for_each_union(parse_node)
             m.for_each_interface(parse_node)
 
         parse_module(self)

--- a/idl_parser/module.py
+++ b/idl_parser/module.py
@@ -12,7 +12,7 @@ class IDLModule(node.IDLNode):
         self._verbose = False
         if name is None:
             self._name = global_namespace
-            
+
         self._interfaces = []
         self._typedefs = []
         self._structs = []
@@ -24,7 +24,7 @@ class IDLModule(node.IDLNode):
     @property
     def is_global(self):
         return self.name == global_namespace
-        
+
     @property
     def full_path(self):
         if self.parent is None:
@@ -37,16 +37,16 @@ class IDLModule(node.IDLNode):
     def to_simple_dic(self, quiet=False):
         dic = {'module %s' % self.name : [s.to_simple_dic(quiet) for s in self.structs] +
                [i.to_simple_dic(quiet) for i in self.interfaces] +
-               [m.to_simple_dic(quiet) for m in self.modules] + 
-               [e.to_simple_dic(quiet) for e in self.enums] + 
-               [u.to_simple_dic(quiet) for e in self.unions] + 
-               [t.to_simple_dic(quiet) for t in self.typedefs] + 
+               [m.to_simple_dic(quiet) for m in self.modules] +
+               [e.to_simple_dic(quiet) for e in self.enums] +
+               [u.to_simple_dic(quiet) for e in self.unions] +
+               [t.to_simple_dic(quiet) for t in self.typedefs] +
                [t.to_simple_dic(quiet) for t in self.consts]}
         return dic
 
     def to_dic(self):
         dic = { 'name' : self.name,
-                'filepath' : self.filepath, 
+                'filepath' : self.filepath,
                 'classname' : self.classname,
                 'interfaces' : [i.to_dic() for i in self.interfaces],
                 'typedefs' : [t.to_dic() for t in self.typedefs],
@@ -56,7 +56,7 @@ class IDLModule(node.IDLNode):
                 'modules' : [m.to_dic() for m in self.modules],
                 'consts' : [c.to_dic() for c in self.consts] }
         return dic
-    
+
 
     def parse_tokens(self, token_buf, filepath=None):
         self._filepath = filepath
@@ -115,7 +115,7 @@ class IDLModule(node.IDLNode):
                 #    raise InvalidIDLSyntaxError
                 else:
                     self._interfaces.append(s)
-            
+
             elif token == 'enum':
                 name_ = token_buf.pop()
                 s = enum.IDLEnum(name_, self)
@@ -158,10 +158,10 @@ class IDLModule(node.IDLNode):
                     if self._verbose: sys.stdout.write('# Error. Same Const Defined (%s)\n' % name_)
                 else:
                     self._consts.append(s)
-                
+
             elif token == '}':
                 break
-            
+
         return True
 
 
@@ -266,7 +266,7 @@ class IDLModule(node.IDLNode):
         for m in self.consts:
             retval.append(func(m))
         return retval
-            
+
 
     @property
     def typedefs(self):

--- a/idl_parser/module.py
+++ b/idl_parser/module.py
@@ -39,7 +39,7 @@ class IDLModule(node.IDLNode):
                [i.to_simple_dic(quiet) for i in self.interfaces] +
                [m.to_simple_dic(quiet) for m in self.modules] +
                [e.to_simple_dic(quiet) for e in self.enums] +
-               [u.to_simple_dic(quiet) for e in self.unions] +
+               [u.to_simple_dic(quiet) for u in self.unions] +
                [t.to_simple_dic(quiet) for t in self.typedefs] +
                [t.to_simple_dic(quiet) for t in self.consts]}
         return dic
@@ -52,7 +52,7 @@ class IDLModule(node.IDLNode):
                 'typedefs' : [t.to_dic() for t in self.typedefs],
                 'structs' : [s.to_dic() for s in self.structs],
                 'enums' : [e.to_dic() for e in self.enums],
-                'unions' : [u.to_dic() for e in self.unions],
+                'unions' : [u.to_dic() for u in self.unions],
                 'modules' : [m.to_dic() for m in self.modules],
                 'consts' : [c.to_dic() for c in self.consts] }
         return dic

--- a/idl_parser/node.py
+++ b/idl_parser/node.py
@@ -13,7 +13,7 @@ class IDLNode(object):
     @property
     def is_array(self):
         return self._classname == 'IDLArray'
-    
+
     @property
     def is_void(self):
         return self._classname == 'IDLVoid'

--- a/idl_parser/node.py
+++ b/idl_parser/node.py
@@ -43,6 +43,10 @@ class IDLNode(object):
         return self._classname == 'IDLEnum'
 
     @property
+    def is_union(self):
+        return self._classname == 'IDLUnion'
+
+    @property
     def is_const(self):
         return self._classname == 'IDLConst'
 
@@ -102,14 +106,17 @@ class IDLNode(object):
 
     def refine_typename(self, typ):
         global_module = self.root_node
-        if typ.find('sequence') >= 0:
-            typ_ = typ[typ.find('<')+1 : typ.find('>')]
-            typ__ = self.refine_typename(typ_)
-            return 'sequence < ' + typ__ + ' >'
+        if typ.name.find('sequence') >= 0:
+            typs = global_module.find_types(typ.name[typ.name.find('<')+1 : typ.name.find('>')])
+            if len(typs) == 0:
+                typ__ = typs
+            else:
+                typ__  = typs[0]
+            print typ__
+            return 'sequence < ' + typ__.name + ' >'
         else:
-        #f True:
-            typs = global_module.find_types(typ)
+            typs = global_module.find_types(typ.name)
             if len(typs) == 0:
                 return typ
             else:
-                return typs[0].full_path
+                return typs[0].name

--- a/idl_parser/node.py
+++ b/idl_parser/node.py
@@ -107,12 +107,13 @@ class IDLNode(object):
     def refine_typename(self, typ):
         global_module = self.root_node
         if typ.name.find('sequence') >= 0:
-            typs = global_module.find_types(typ.name[typ.name.find('<')+1 : typ.name.find('>')])
+            name = typ.name[typ.name.find('<')+1 : typ.name.find('>')].strip()
+            typs = global_module.find_types(name)
             if len(typs) == 0:
                 typ__ = typs
             else:
                 typ__  = typs[0]
-            print typ__
+
             return 'sequence < ' + typ__.name + ' >'
         else:
             typs = global_module.find_types(typ.name)

--- a/idl_parser/parser.py
+++ b/idl_parser/parser.py
@@ -9,7 +9,7 @@ class IDLParser():
         self._global_module = module.IDLModule()
         self._dirs = idl_dirs
         self._verbose = False
-        
+
     @property
     def global_module(self):
         return self._global_module
@@ -51,7 +51,7 @@ class IDLParser():
     def parse_lines(self, lines, filepath=None):
 
         lines = self._clear_comments(lines)
-        lines = self._paste_include(lines)            
+        lines = self._paste_include(lines)
         lines = self._clear_ifdef(lines)
 
         self._token_buf = token_buffer.TokenBuffer(lines)
@@ -78,7 +78,7 @@ class IDLParser():
         self.for_each_idl(get_fullpath)
         if len(included_filenames) > 0:
             raise IDLCanNotFindException()
-                
+
         return included_filepaths
 
 
@@ -110,14 +110,14 @@ class IDLParser():
 
     def _find_idl(self, filename, apply_func, idl_dirs=[]):
         if self._verbose: sys.stdout.write(' --- Find %s\n' % filename)
-        
+
         global retval
         retval = None
         def func(filepath):
             if os.path.basename(filepath) == filename:
                 global retval
                 retval = apply_func(filepath)
-                
+
         self.for_each_idl(func, idl_dirs=idl_dirs)
         return retval
 
@@ -166,7 +166,7 @@ class IDLParser():
 
             else:
                 output_line = line
-                
+
             output_lines.append(output_line)
 
         return output_lines
@@ -184,7 +184,7 @@ class IDLParser():
                 line = line[:line.find('//')]
 
             for token in line.split(' '):
-                
+
                 if in_comment and token.find('*/') >= 0:
                     in_comment = False
                     output_line = output_line + ' ' + token[token.find('*/')+2:].strip()
@@ -194,13 +194,15 @@ class IDLParser():
 
                 elif token.startswith('//'):
                     break # ignore this line
-                
+
                 elif token.find('/*') >= 0:
                     in_comment = True
                     output_line = output_line + ' ' + token[0: token.find('/*')]
                 else:
                     if token.find('{') >= 0:
                         token = token.replace('{', ' { ')
+                    if token.find(':') >= 0:
+                        token = token.replace(':', ' : ')
                     if token.find(';') >= 0:
                         token = token.replace(';', ' ;')
                     if token.find('(') >= 0:
@@ -211,7 +213,7 @@ class IDLParser():
                     output_line = output_line + ' ' + token.strip()
             if len(output_line.strip()) > 0:
                 output_lines.append(output_line.strip() + '\n')
-        
+
         return output_lines
 
     def _clear_ifdef(self, lines):

--- a/idl_parser/struct.py
+++ b/idl_parser/struct.py
@@ -63,8 +63,7 @@ class IDLMember(node.IDLNode):
 
 
     def post_process(self):
-        #self._type = self.refine_typename(self.type)
-        pass
+        self._type._name = self.refine_typename(self.type)
 
 
 class IDLStruct(node.IDLNode):

--- a/idl_parser/struct.py
+++ b/idl_parser/struct.py
@@ -10,7 +10,7 @@ class IDLMember(node.IDLNode):
         self._verbose = True
         self._type = None
         self.sep = '::'
-    
+
     @property
     def full_path(self):
         return self.parent.full_path + self.sep + self.name
@@ -31,7 +31,7 @@ class IDLMember(node.IDLNode):
                 return str(self.type) + ' ' + self.name
             elif self.type.obj.is_enum:
                 return str('enum') + ' ' + self.name
-            dic = {str(self.type) +' ' + self.name : 
+            dic = {str(self.type) +' ' + self.name :
                    self.type.obj.to_simple_dic(recursive=recursive, member_only=True)}
             return dic
         dic = {self.name : str(self.type) }
@@ -39,7 +39,7 @@ class IDLMember(node.IDLNode):
 
     def to_dic(self):
         dic = { 'name' : self.name,
-                'filepath' : self.filepath, 
+                'filepath' : self.filepath,
                 'classname' : self.classname,
                 'type' : str(self.type) }
         return dic
@@ -60,21 +60,21 @@ class IDLMember(node.IDLNode):
             if self.type.is_typedef:
                 return self.type.type
         return self.type
-    
+
 
     def post_process(self):
         #self._type = self.refine_typename(self.type)
         pass
-                
+
 
 class IDLStruct(node.IDLNode):
-    
+
     def __init__(self, name, parent):
         super(IDLStruct, self).__init__('IDLStruct', name.strip(), parent)
         self._verbose = True
         self._members = []
         self.sep = '::'
-        
+
     @property
     def full_path(self):
         return (self.parent.full_path + self.sep + self.name).strip()
@@ -82,43 +82,43 @@ class IDLStruct(node.IDLNode):
     def to_simple_dic(self, quiet=False, full_path=False, recursive=False, member_only=False):
         name = self.full_path if full_path else self.name
         if quiet:
-            return 'struct %s' % name 
-        
+            return 'struct %s' % name
+
         dic = { 'struct %s' % name : [v.to_simple_dic(recursive=recursive) for v in self.members] }
 
         if member_only:
             return dic.values()[0]
         return dic
-                    
+
 
     def to_dic(self):
         dic = { 'name' : self.name,
                 'classname' : self.classname,
                 'members' : [v.to_dic() for v in self.members] }
         return dic
-    
+
     def parse_tokens(self, token_buf, filepath=None):
         self._filepath = filepath
         kakko = token_buf.pop()
         if not kakko == '{':
             if self._verbose: sys.stdout.write('# Error. No kakko "{".\n')
             raise InvalidIDLSyntaxError()
-        
-        block_tokens = []        
+
+        block_tokens = []
         while True:
 
             token = token_buf.pop()
             if token == None:
                 if self._verbose: sys.stdout.write('# Error. No kokka "}".\n')
                 raise InvalidIDLSyntaxError()
-            
+
             elif token == '}':
                 token = token_buf.pop()
                 if not token == ';':
                     if self._verbose: sys.stdout.write('# Error. No semi-colon after "}".\n')
                     raise InvalidIDLSyntaxError()
                 break
-            
+
             if token == ';':
                 self._parse_block(block_tokens)
                 block_tokens = []
@@ -126,12 +126,12 @@ class IDLStruct(node.IDLNode):
             block_tokens.append(token)
 
         self._post_process()
-            
+
     def _parse_block(self, blocks):
         v = IDLMember(self)
         v.parse_blocks(blocks, self.filepath)
         self._members.append(v)
-    
+
     def _post_process(self):
         self.forEachMember(lambda m : m.post_process())
 
@@ -143,7 +143,7 @@ class IDLStruct(node.IDLNode):
         for m in self._members:
             if m.name == name:
                 return m
-    
+
         return None
     def forEachMember(self, func):
         for m in self._members:

--- a/idl_parser/type.py
+++ b/idl_parser/type.py
@@ -6,14 +6,14 @@ sep = '::'
 
 primitive = [
     'boolean',
-    'char', 'byte', 'octet', 
-    'short', 'wchar', 
-    'long', 
+    'char', 'byte', 'octet',
+    'short', 'wchar',
+    'long',
     'float',
     'double',
     'string',
     'wstring']
-           
+
 def is_primitive(name):
     for n in name.split(' '):
         if n in primitive:
@@ -63,7 +63,7 @@ class IDLSequence(IDLTypeBase):
         self._verbose = True
         if name.find('sequence') < 0:
             raise InvalidIDLSyntaxError()
-        typ_ = name[name.find('<')+1 : name.find('>')]
+        typ_ = name[name.find('<')+1 : name.find('>')].strip()
         self._type = IDLType(typ_, parent)
         self._is_primitive = False #self.inner_type.is_primitive
         self._is_sequence = True
@@ -74,7 +74,7 @@ class IDLSequence(IDLTypeBase):
 
     def __str__(self):
         return 'sequence<%s>' % str(self.inner_type)
-    
+
     @property
     def obj(self):
         return self
@@ -163,14 +163,14 @@ class IDLArray(IDLTypeBase):
             n[0] = n[0] + '[%s]' % typ.size
             if typ.inner_type.is_array:
                 _apply_size(typ.inner_type)
-        
+
         _apply_size(self)
         return n[0]
-    
+
     @property
     def obj(self):
         return self
-    
+
     @property
     def size(self):
         return self._size
@@ -201,9 +201,9 @@ class IDLArray(IDLTypeBase):
 
         if recursive:
             if self.type.is_primitive:
-                return str(self) 
+                return str(self)
             else:
-                return str(self) 
+                return str(self)
         """
             n = 'typedef ' + str(self.type) +' ' + name
             if not self.type.is_primitive:
@@ -224,21 +224,23 @@ class IDLArray(IDLTypeBase):
                 'type' : str(self.type) }
         return dic
 
-        
+
 class IDLPrimitive(IDLTypeBase):
     def __init__(self, name, parent):
         super(IDLPrimitive, self).__init__('IDLPrimitive', name, parent.root_node)
         self._verbose = True
         self._is_primitive = True
-
+    @property
+    def full_path(self):
+        return (self.parent.full_path + self.sep + self.name).strip()
 class IDLBasicType(IDLTypeBase):
     def __init__(self, name, parent):
         super(IDLBasicType, self).__init__('IDLBasicType', name, parent.root_node)
         self._verbose = True
         #if self.name.find('['):
         #    self._name = self.name[self.name.find('[')+1:]
-        self._name = self.refine_typename(self.name)
-        
+        self._name = self.refine_typename(self)
+
     @property
     def obj(self):
         global_module = self.root_node

--- a/idl_parser/typedef.py
+++ b/idl_parser/typedef.py
@@ -3,7 +3,7 @@ from . import type as idl_type
 sep = '::'
 
 class IDLTypedef(node.IDLNode):
-    
+
     def __init__(self, parent):
         super(IDLTypedef, self).__init__('IDLTypedef', '', parent)
         self._verbose = True
@@ -49,7 +49,7 @@ class IDLTypedef(node.IDLNode):
                 return self.type.type
         return self.type
 
-    
+
     def parse_blocks(self, blocks, filepath=None):
         self._filepath = filepath
         type_name_ = ''
@@ -58,7 +58,7 @@ class IDLTypedef(node.IDLNode):
         while True:
             if name.find('[') < 0:
                 break
-            
+
             if name.find('[') > 0:
                 type_name_ = name[name.find('['):]
                 name = name[:name.find('[')]
@@ -81,5 +81,4 @@ class IDLTypedef(node.IDLNode):
         self._post_process()
 
     def _post_process(self):
-        #self._type = self.refine_typename(self.type)
-        pass
+        self._type._name = self.refine_typename(self.type)

--- a/idl_parser/union.py
+++ b/idl_parser/union.py
@@ -55,12 +55,12 @@ class IDLUnionMember(node.IDLNode):
                 'descriminator_value_associations' : self.descriminator_value_associations,
                 'filepath' : self.filepath,
                 'classname' : self.classname,
-                'type' : str(self.type) }
+                'type' : self.type.name }
         return dic
 
     @property
     def type(self):
-        if self._type.classname == 'IDLBasicType': # Struct
+        if self._type.classname == 'IDLBasicType': # Union
             typs = self.root_node.find_types(self._type.name)
             if len(typs) == 0:
                 print('Can not find Data Type (%s)\n' % self._type.name)
@@ -78,11 +78,8 @@ class IDLUnionMember(node.IDLNode):
                 return self.type.type
         return self.type
 
-
     def post_process(self):
-        #self._type = self.refine_typename(self.type)
-        pass
-
+        self._type._name = self.refine_typename(self.type)
 
 class IDLUnion(node.IDLNode):
 

--- a/idl_parser/union.py
+++ b/idl_parser/union.py
@@ -1,0 +1,151 @@
+import os, sys, traceback
+
+from . import node
+from . import type as idl_type
+
+
+class IDLUnionMember(node.IDLNode):
+    def __init__(self, parent):
+        super(IDLUnionMember, self).__init__('IDLUnionMember', '', parent)
+        self._verbose = True
+        self._type = None
+        self.sep = '::'
+    
+    @property
+    def full_path(self):
+        return self.parent.full_path + self.sep + self.name
+
+    def parse_blocks(self, blocks, filepath=None):
+        self._filepath = filepath
+        name, typ = self._name_and_type(blocks)
+        if name.find('[') >= 0:
+            name_ = name[:name.find('[')]
+            typ = typ.strip() + ' ' + name[name.find('['):]
+            name = name_
+        self._name = name
+        self._type = idl_type.IDLType(typ, self)
+
+    def to_simple_dic(self, recursive=False, member_only=False):
+        if recursive:
+            if self.type.is_primitive:
+                return str(self.type) + ' ' + self.name
+            elif self.type.obj.is_enum:
+                return str('enum') + ' ' + self.name
+            dic = {str(self.type) +' ' + self.name : 
+                   self.type.obj.to_simple_dic(recursive=recursive, member_only=True)}
+            return dic
+        dic = {self.name : str(self.type) }
+        return dic
+
+    def to_dic(self):
+        dic = { 'name' : self.name,
+                'filepath' : self.filepath, 
+                'classname' : self.classname,
+                'type' : str(self.type) }
+        return dic
+
+    @property
+    def type(self):
+        if self._type.classname == 'IDLBasicType': # Struct
+            typs = self.root_node.find_types(self._type.name)
+            if len(typs) == 0:
+                print('Can not find Data Type (%s)\n' % self._type.name)
+                raise InvalidDataTypeException()
+            return typs[0]
+        return self._type
+
+
+    def get_type(self, extract_typedef=False):
+        if extract_typedef:
+            if self.type.is_typedef:
+                return self.type.type
+        return self.type
+    
+
+    def post_process(self):
+        #self._type = self.refine_typename(self.type)
+        pass
+                
+
+class IDLUnion(node.IDLNode):
+    
+    def __init__(self, name, parent):
+        super(IDLUnion, self).__init__('IDLUnion', name.strip(), parent)
+        self._verbose = True
+        self._members = []
+        self.sep = '::'
+        
+    @property
+    def full_path(self):
+        return (self.parent.full_path + self.sep + self.name).strip()
+
+    def to_simple_dic(self, quiet=False, full_path=False, recursive=False, member_only=False):
+        name = self.full_path if full_path else self.name
+        if quiet:
+            return 'union %s' % name 
+        
+        dic = { 'union %s' % name : [v.to_simple_dic(recursive=recursive) for v in self.members] }
+
+        if member_only:
+            return dic.values()[0]
+        return dic
+                    
+
+    def to_dic(self):
+        dic = { 'name' : self.name,
+                'classname' : self.classname,
+                'members' : [v.to_dic() for v in self.members] }
+        return dic
+    
+    def parse_tokens(self, token_buf, filepath=None):
+        self._filepath = filepath
+        kakko = token_buf.pop()
+
+        if not kakko == '{':
+            if self._verbose: sys.stdout.write('# Error. No kakko "{".\n')
+            raise InvalidIDLSyntaxError()
+        
+        block_tokens = []        
+        while True:
+
+            token = token_buf.pop()
+            if token == None:
+                if self._verbose: sys.stdout.write('# Error. No kokka "}".\n')
+                raise InvalidIDLSyntaxError()
+            
+            elif token == '}':
+                token = token_buf.pop()
+                if not token == ';':
+                    if self._verbose: sys.stdout.write('# Error. No semi-colon after "}".\n')
+                    raise InvalidIDLSyntaxError()
+                break
+            
+            if token == ';':
+                self._parse_block(block_tokens)
+                block_tokens = []
+                continue
+            block_tokens.append(token)
+
+        self._post_process()
+            
+    def _parse_block(self, blocks):
+        v = IDLUnionMember(self)
+        v.parse_blocks(blocks, self.filepath)
+        self._members.append(v)
+    
+    def _post_process(self):
+        self.forEachMember(lambda m : m.post_process())
+
+    @property
+    def members(self):
+        return self._members
+
+    def member_by_name(self, name):
+        for m in self._members:
+            if m.name == name:
+                return m
+    
+        return None
+    def forEachMember(self, func):
+        for m in self._members:
+            func(m)

--- a/idl_parser/union.py
+++ b/idl_parser/union.py
@@ -9,14 +9,27 @@ class IDLUnionMember(node.IDLNode):
         super(IDLUnionMember, self).__init__('IDLUnionMember', '', parent)
         self._verbose = True
         self._type = None
+        self._descriminator_value_associations = []
         self.sep = '::'
-    
+
     @property
     def full_path(self):
         return self.parent.full_path + self.sep + self.name
 
     def parse_blocks(self, blocks, filepath=None):
         self._filepath = filepath
+
+        while True:
+            if blocks[0] != 'case':
+                break
+            blocks.pop(0)
+            token = blocks.pop(0)
+            self._descriminator_value_associations.append(token)
+            token = blocks.pop(0)
+            if token != ':':
+                if self._verbose: sys.stdout.write('# Error. No ":" after case value.\n')
+                raise InvalidDataTypeException()
+
         name, typ = self._name_and_type(blocks)
         if name.find('[') >= 0:
             name_ = name[:name.find('[')]
@@ -31,7 +44,7 @@ class IDLUnionMember(node.IDLNode):
                 return str(self.type) + ' ' + self.name
             elif self.type.obj.is_enum:
                 return str('enum') + ' ' + self.name
-            dic = {str(self.type) +' ' + self.name : 
+            dic = {str(self.type) +' ' + self.name :
                    self.type.obj.to_simple_dic(recursive=recursive, member_only=True)}
             return dic
         dic = {self.name : str(self.type) }
@@ -39,7 +52,8 @@ class IDLUnionMember(node.IDLNode):
 
     def to_dic(self):
         dic = { 'name' : self.name,
-                'filepath' : self.filepath, 
+                'descriminator_value_associations' : self.descriminator_value_associations,
+                'filepath' : self.filepath,
                 'classname' : self.classname,
                 'type' : str(self.type) }
         return dic
@@ -54,27 +68,31 @@ class IDLUnionMember(node.IDLNode):
             return typs[0]
         return self._type
 
+    @property
+    def descriminator_value_associations(self):
+        return self._descriminator_value_associations
 
     def get_type(self, extract_typedef=False):
         if extract_typedef:
             if self.type.is_typedef:
                 return self.type.type
         return self.type
-    
+
 
     def post_process(self):
         #self._type = self.refine_typename(self.type)
         pass
-                
+
 
 class IDLUnion(node.IDLNode):
-    
+
     def __init__(self, name, parent):
         super(IDLUnion, self).__init__('IDLUnion', name.strip(), parent)
         self._verbose = True
+        self._descriminator_kind = None
         self._members = []
         self.sep = '::'
-        
+
     @property
     def full_path(self):
         return (self.parent.full_path + self.sep + self.name).strip()
@@ -82,44 +100,46 @@ class IDLUnion(node.IDLNode):
     def to_simple_dic(self, quiet=False, full_path=False, recursive=False, member_only=False):
         name = self.full_path if full_path else self.name
         if quiet:
-            return 'union %s' % name 
-        
+            return 'union %s' % name
+
         dic = { 'union %s' % name : [v.to_simple_dic(recursive=recursive) for v in self.members] }
 
         if member_only:
             return dic.values()[0]
         return dic
-                    
 
     def to_dic(self):
         dic = { 'name' : self.name,
                 'classname' : self.classname,
+                'descriminator_kind' : self.descriminator_kind,
                 'members' : [v.to_dic() for v in self.members] }
         return dic
-    
+
     def parse_tokens(self, token_buf, filepath=None):
         self._filepath = filepath
-        kakko = token_buf.pop()
 
-        if not kakko == '{':
-            if self._verbose: sys.stdout.write('# Error. No kakko "{".\n')
+        self.parse_descriminator_kind(token_buf)
+
+        token = token_buf.pop()
+        if token != '{':
+            if self._verbose: sys.stdout.write('# Error. No kokka "{".\n')
             raise InvalidIDLSyntaxError()
-        
-        block_tokens = []        
+
+        block_tokens = []
         while True:
 
             token = token_buf.pop()
             if token == None:
                 if self._verbose: sys.stdout.write('# Error. No kokka "}".\n')
                 raise InvalidIDLSyntaxError()
-            
+
             elif token == '}':
                 token = token_buf.pop()
                 if not token == ';':
                     if self._verbose: sys.stdout.write('# Error. No semi-colon after "}".\n')
                     raise InvalidIDLSyntaxError()
                 break
-            
+
             if token == ';':
                 self._parse_block(block_tokens)
                 block_tokens = []
@@ -127,12 +147,28 @@ class IDLUnion(node.IDLNode):
             block_tokens.append(token)
 
         self._post_process()
-            
+
+    def parse_descriminator_kind(self, token_buf):
+        token = token_buf.pop()
+        if token != 'switch':
+            if self._verbose: sys.stdout.write('# Error. Union definition missing "switch".\n')
+            raise InvalidIDLSyntaxError()
+        token = token_buf.pop()
+        if token != '(':
+            if self._verbose: sys.stdout.write('# Error. No "(".\n')
+            raise InvalidIDLSyntaxError()
+        token = token_buf.pop()
+        self._descriminator_kind = token
+        token = token_buf.pop()
+        if token != ')':
+            if self._verbose: sys.stdout.write('# Error. No ")".\n')
+            raise InvalidIDLSyntaxError()
+
     def _parse_block(self, blocks):
         v = IDLUnionMember(self)
         v.parse_blocks(blocks, self.filepath)
         self._members.append(v)
-    
+
     def _post_process(self):
         self.forEachMember(lambda m : m.post_process())
 
@@ -140,11 +176,15 @@ class IDLUnion(node.IDLNode):
     def members(self):
         return self._members
 
+    @property
+    def descriminator_kind(self):
+        return self._descriminator_kind
+
     def member_by_name(self, name):
         for m in self._members:
             if m.name == name:
                 return m
-    
+
         return None
     def forEachMember(self, func):
         for m in self._members:

--- a/idls/basic_module_test.idl
+++ b/idls/basic_module_test.idl
@@ -25,6 +25,29 @@ module my_module {
     double double_member;
   };
 
+  enum my_union1_descriminator_kind
+  {
+      descriminator_unknown,
+      descriminator_ulonglong,
+      descriminator_longlong,
+      descriminator_double,
+      descriminator_string,
+      descriminator_kind_count
+  };
+
+  union my_union1 switch( my_union1_descriminator_kind )
+  {
+      case descriminator_unknown:
+      case descriminator_kind_count:
+      case descriminator_ulonglong:
+          unsigned long long      ull_value;
+      case descriminator_longlong:
+          long long               ll_value;
+      case descriminator_double:
+          double                  d_value;
+      case descriminator_string:
+          sequence<char>          str_value;
+  };
 
   typedef octet my_byte;
   typedef my_struct1 my_struct_typedef;
@@ -37,7 +60,7 @@ module my_module {
   typedef sequence<double> DoubleSeq;
 
   enum my_enum1 {
-    data1, 
+    data1,
     data2,
     data3,
   };
@@ -48,6 +71,6 @@ module my_module {
   typedef double Matrix34[3][4];
 
   typedef unsigned long  Matrix3456[3][4][5][6];
-  
+
 };
 

--- a/tests/module_test.py
+++ b/tests/module_test.py
@@ -1,7 +1,7 @@
 import os, sys
 import unittest
 from idl_parser import parser
-
+from idl_parser.type import IDLType
 
 from coveralls import Coveralls
 from coveralls.api import log
@@ -29,12 +29,12 @@ class BasicTestFunctions(unittest.TestCase):
         my_module = m.modules[0]
         self.assertEqual(my_module.name, 'my_module')
         my_struct = my_module.struct_by_name('my_struct3')
-        self.assertEqual(my_struct.name, 'my_struct3') 
+        self.assertEqual(my_struct.name, 'my_struct3')
 
         typenames = {
             'octet': 'octet_member',
             'unsigned long': 'ulong_member',
-            
+
             'char': 'char_member',
             'wchar': 'wchar_member',
             'string': 'string_member',
@@ -78,7 +78,7 @@ class BasicTestFunctions(unittest.TestCase):
         self.assertEqual(m.name,'__global__')
         my_module = m.modules[0]
         self.assertEqual(my_module.name, 'my_module')
-        
+
         my_int = my_module.interface_by_name('my_interface1')
         self.assertEqual(my_int.basename, 'my_interface1')
         method1 = my_int.method_by_name('method1')
@@ -121,6 +121,45 @@ class BasicTestFunctions(unittest.TestCase):
         my_struct = m.type
         self.assertTrue(my_struct.is_struct)
 
+    def test_union_types(self):
+        parser_ = parser.IDLParser()
+        m = parser_.load(open(idl_path, 'r').read())
+        self.assertEqual(m.name,'__global__')
+        my_module = m.modules[0]
+        self.assertEqual(my_module.name, 'my_module')
+        my_union_1 = my_module.union_by_name('my_union1')
+        self.assertEqual(my_union_1.basename, 'my_union1')
+        self.assertTrue(my_union_1.is_union)
+
+        m = my_union_1.member_by_name('ull_value')
+        self.assertEqual(m.type.name, 'unsigned long long')
+        self.assertIn(
+            'descriminator_unknown',
+            m.descriminator_value_associations)
+        self.assertIn(
+            'descriminator_kind_count',
+            m.descriminator_value_associations)
+        self.assertIn(
+            'descriminator_ulonglong',
+            m.descriminator_value_associations)
+        m = my_union_1.member_by_name('ll_value')
+        self.assertEqual(m.type.name, 'long long')
+        self.assertIn(
+            'descriminator_longlong',
+            m.descriminator_value_associations)
+        m = my_union_1.member_by_name('d_value')
+        self.assertEqual(m.type.name, 'double')
+        self.assertIn(
+            'descriminator_double',
+            m.descriminator_value_associations)
+        m = my_union_1.member_by_name('str_value')
+        sequence_type = IDLType(m.type.name, m.parent)
+        self.assertTrue(sequence_type.is_sequence)
+        self.assertEqual(sequence_type.inner_type.name, 'char')
+        self.assertIn(
+            'descriminator_string',
+            m.descriminator_value_associations)
+
     def test_enum_types(self):
         parser_ = parser.IDLParser()
         m = parser_.load(open(idl_path, 'r').read())
@@ -131,11 +170,11 @@ class BasicTestFunctions(unittest.TestCase):
         my_enum1 = my_module.enum_by_name('my_enum1')
         self.assertEqual(my_enum1.name, 'my_enum1')
         self.assertTrue(my_enum1.is_enum)
-        
+
         self.assertEqual(my_enum1.value_by_name('data1').value, 0)
         self.assertEqual(my_enum1.value_by_name('data2').value, 1)
         self.assertEqual(my_enum1.value_by_name('data3').value, 2)
-        
+
 
     def test_const_types(self):
         parser_ = parser.IDLParser()
@@ -153,7 +192,7 @@ class BasicTestFunctions(unittest.TestCase):
         self.assertTrue(value2.is_const)
         self.assertEqual(value2.value_string, '4')
         self.assertEqual(value2.type.name, 'unsigned long')
-        
+
     def test_sequence_test(self):
         parser_ = parser.IDLParser()
         m = parser_.load(open(idl_path, 'r').read())
@@ -166,7 +205,7 @@ class BasicTestFunctions(unittest.TestCase):
         seq_double = doubleSeq.type
         self.assertTrue(seq_double.is_sequence)
         self.assertEqual(seq_double.inner_type.name, 'double')
-        
+
     def test_arraye_test(self):
         parser_ = parser.IDLParser()
         m = parser_.load(open(idl_path, 'r').read())
@@ -180,7 +219,7 @@ class BasicTestFunctions(unittest.TestCase):
         arr_arr_double = mat34.type
         self.assertTrue(arr_arr_double.is_array)
         self.assertEqual(arr_arr_double.size, 3)
-        
+
         arr_double = arr_arr_double.inner_type
         self.assertEqual(arr_double.name, 'double [4]')
         self.assertTrue(arr_double.is_array)
@@ -194,7 +233,7 @@ class BasicTestFunctions(unittest.TestCase):
         arr_arr_arr_arr_ul = mat3456.type
         self.assertTrue(arr_arr_arr_arr_ul.is_array)
         self.assertEqual(arr_arr_arr_arr_ul.size, 3)
-        
+
         arr_arr_arr_ul = arr_arr_arr_arr_ul.inner_type
         self.assertTrue(arr_arr_arr_ul.is_array)
         self.assertEqual(arr_arr_arr_ul.size, 4)
@@ -207,8 +246,8 @@ class BasicTestFunctions(unittest.TestCase):
         self.assertTrue(arr_ul.is_array)
         self.assertEqual(arr_ul.size, 6)
         self.assertTrue(arr_ul.inner_type.name, 'unsigned long')
-        
-        
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Add support for DDS Union types
Prior to this commit there was no support for parsing DDS Unions.
As a user looking to parse OMG IDL files with union types I was
unable harness the power of the rest of the tool until unions
were supported. This commit represents the addition of parsing support
for union types defined in an OMG IDL file.

Because my use case benefits from the functionality of the
`refine_typename` method of the IDLNode class, I revised
some of its logic and the logic it requires then uncommented
its use in each of the modules that had disabled it.

Further, tests were added to the module_test.py suite to validate
the parser's handling of union types.